### PR TITLE
Refactor to use opentofu/registry-address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go.work*
+.tool-versions

--- a/earlydecoder/decoder.go
+++ b/earlydecoder/decoder.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/module"
 )

--- a/earlydecoder/decoder.go
+++ b/earlydecoder/decoder.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/module"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 func LoadModule(path string, files map[string]*hcl.File) (*module.Meta, hcl.Diagnostics) {

--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/backend"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/module"

--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/backend"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/module"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -1377,7 +1377,7 @@ module "name" {
 			"modules with source",
 			`
 module "name" {
-	source = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+	source = "registry.opentofu.org/terraform-aws-modules/vpc/aws"
 }`,
 			&module.Meta{
 				Path:                 path,
@@ -1389,8 +1389,8 @@ module "name" {
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
 						LocalName:     "name",
-						RawSourceAddr: "registry.terraform.io/terraform-aws-modules/vpc/aws",
-						SourceAddr:    tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
+						RawSourceAddr: "registry.opentofu.org/terraform-aws-modules/vpc/aws",
+						SourceAddr:    tfaddr.MustParseModuleSource("registry.opentofu.org/terraform-aws-modules/vpc/aws"),
 						InputNames:    []string{},
 						RangePtr: &hcl.Range{
 							Filename: "test.tf",

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/hashicorp/hcl/v2 v2.21.0
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1
-	github.com/hashicorp/terraform-registry-address v0.2.3
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
+	github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a
 	github.com/zclconf/go-cty v1.14.4
 	github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940
 )

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVW
 github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
-github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
-github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -58,6 +56,8 @@ github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5 h1:shw+DWUaHIy
 github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5/go.mod h1:nHPoxaBUc5CDAMIv0MNmn5PBjWbTs9BI/eh30/n0U6g=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a h1:NyM/PPbc+kxxv2d4OKfE32C5fLtVTLceyg4YKKCYO9Y=
+github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a/go.mod h1:HzQhpVo/NJnGmN+7FPECCVCA5ijU7AUcvf39enBKYOc=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/internal/addr/addr.go
+++ b/internal/addr/addr.go
@@ -6,7 +6,7 @@
 package addr
 
 import (
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 // NewLegacyProvider returns a mock address for a provider.

--- a/module/meta.go
+++ b/module/meta.go
@@ -7,8 +7,8 @@ package module
 
 import (
 	"github.com/hashicorp/go-version"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/backend"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 type Meta struct {

--- a/module/meta.go
+++ b/module/meta.go
@@ -7,7 +7,7 @@ package module
 
 import (
 	"github.com/hashicorp/go-version"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/backend"
 )
 

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/detect"
 )
 

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/detect"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 var moduleSourceLocalPrefixes = []string{

--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	tfjson "github.com/hashicorp/terraform-json"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )

--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -367,7 +367,7 @@ func urlForProvider(addr tfaddr.Provider, v *version.Version) string {
 		ver = v.String()
 	}
 
-	return fmt.Sprintf("https://registry.terraform.io/providers/%s/%s/%s/docs",
+	return fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/%s/",
 		addr.Namespace, addr.Type, ver)
 }
 
@@ -383,10 +383,11 @@ func providerHasDocs(addr tfaddr.Provider) bool {
 		return false
 	}
 
-	if addr.Hostname != "registry.terraform.io" {
+	if addr.Hostname != "registry.opentofu.org" {
 		// docs URLs outside of the official Registry aren't standardized yet
 		return false
 	}
+
 	return true
 }
 

--- a/schema/functions_merge_test.go
+++ b/schema/functions_merge_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
 	tfjson "github.com/hashicorp/terraform-json"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/zclconf/go-cty-debug/ctydebug"

--- a/schema/functions_merge_test.go
+++ b/schema/functions_merge_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
 	tfjson "github.com/hashicorp/terraform-json"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	tfmod "github.com/opentofu/opentofu-schema/module"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -60,7 +60,7 @@ func TestFunctionsMerger_FunctionsForModule_noMeta(t *testing.T) {
 }
 
 var providerSchemaWithFunctions = map[string]*tfjson.ProviderSchema{
-	"registry.terraform.io/hashicorp/test": {
+	"registry.opentofu.org/hashicorp/test": {
 		ConfigSchema:      &tfjson.Schema{},
 		DataSourceSchemas: map[string]*tfjson.Schema{},
 		ResourceSchemas:   map[string]*tfjson.Schema{},

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -87,7 +87,7 @@ func schemaForDependentRegistryModuleBlock(module module.DeclaredModuleCall, mod
 	})
 
 	sourceAddr, ok := module.SourceAddr.(tfaddr.Module)
-	if ok && sourceAddr.Package.Host == "registry.terraform.io" {
+	if ok && sourceAddr.Package.Host == "registry.opentofu.org" {
 		versionStr := ""
 		if modMeta.Version == nil {
 			versionStr = "latest"
@@ -97,7 +97,7 @@ func schemaForDependentRegistryModuleBlock(module module.DeclaredModuleCall, mod
 
 		bodySchema.DocsLink = &schema.DocsLink{
 			URL: fmt.Sprintf(
-				`https://registry.terraform.io/modules/%s/%s`,
+				`https://search.opentofu.org/module/%s/%s`,
 				sourceAddr.Package.ForRegistryProtocol(),
 				versionStr,
 			),
@@ -235,7 +235,7 @@ func schemaForDependentModuleBlock(module module.DeclaredModuleCall, modMeta *mo
 	}
 
 	registryAddr, ok := module.SourceAddr.(tfaddr.Module)
-	if ok && registryAddr.Package.Host == "registry.terraform.io" {
+	if ok && registryAddr.Package.Host == "registry.opentofu.org" {
 		versionStr := ""
 		if module.Version == nil {
 			versionStr = "latest"
@@ -245,7 +245,7 @@ func schemaForDependentModuleBlock(module module.DeclaredModuleCall, modMeta *mo
 
 		bodySchema.DocsLink = &schema.DocsLink{
 			URL: fmt.Sprintf(
-				`https://registry.terraform.io/modules/%s/%s`,
+				`https://search.opentofu.org/module/%s/%s`,
 				registryAddr.Package.ForRegistryProtocol(),
 				versionStr,
 			),

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -365,14 +365,14 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 		{
 			"remote module",
 			&module.Meta{
-				Path:      "registry.terraform.io/terraform-aws-modules/vpc/aws",
+				Path:      "registry.opentofu.org/terraform-aws-modules/vpc/aws",
 				Variables: map[string]module.Variable{},
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
 			module.DeclaredModuleCall{
 				LocalName:  "vpc",
-				SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
+				SourceAddr: tfaddr.MustParseModuleSource("registry.opentofu.org/terraform-aws-modules/vpc/aws"),
 			},
 			&schema.BodySchema{
 				Attributes: map[string]*schema.AttributeSchema{},
@@ -389,21 +389,21 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				},
 				ImpliedOrigins: schema.ImpliedOrigins{},
 				DocsLink: &schema.DocsLink{
-					URL: "https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest",
+					URL: "https://search.opentofu.org/module/terraform-aws-modules/vpc/aws/latest",
 				},
 			},
 		},
 		{
 			"remote module with version",
 			&module.Meta{
-				Path:      "registry.terraform.io/terraform-aws-modules/vpc/aws",
+				Path:      "registry.opentofu.org/terraform-aws-modules/vpc/aws",
 				Variables: map[string]module.Variable{},
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
 			module.DeclaredModuleCall{
 				LocalName:  "vpc",
-				SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
+				SourceAddr: tfaddr.MustParseModuleSource("registry.opentofu.org/terraform-aws-modules/vpc/aws"),
 				Version:    version.MustConstraints(version.NewConstraint("1.33.7")),
 			},
 			&schema.BodySchema{
@@ -421,7 +421,7 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				},
 				ImpliedOrigins: schema.ImpliedOrigins{},
 				DocsLink: &schema.DocsLink{
-					URL: "https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/1.33.7",
+					URL: "https://search.opentofu.org/module/terraform-aws-modules/vpc/aws/1.33.7",
 				},
 			},
 		},
@@ -558,7 +558,7 @@ func TestSchemaForDeclaredDependentModuleBlock_basic(t *testing.T) {
 			},
 		},
 		DocsLink: &schema.DocsLink{
-			URL: "https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/1.0.0",
+			URL: "https://search.opentofu.org/module/terraform-aws-modules/eks/aws/1.0.0",
 		},
 	}
 	if diff := cmp.Diff(expectedDepSchema, depSchema, ctydebug.CmpOptions); diff != "" {

--- a/schema/provider_schema.go
+++ b/schema/provider_schema.go
@@ -8,7 +8,7 @@ package schema
 import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 )
 
 type ProviderSchema struct {

--- a/schema/provider_schema_test.go
+++ b/schema/provider_schema_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"

--- a/schema/provider_schema_test.go
+++ b/schema/provider_schema_test.go
@@ -56,9 +56,9 @@ func TestProviderSchema_SetProviderVersion(t *testing.T) {
 	expectedSchema := &ProviderSchema{
 		Provider: &schema.BodySchema{
 			Detail:   "hashicorp/aws 1.2.5",
-			HoverURL: "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
+			HoverURL: "https://search.opentofu.org/provider/hashicorp/aws/1.2.5/",
 			DocsLink: &schema.DocsLink{
-				URL:     "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
+				URL:     "https://search.opentofu.org/provider/hashicorp/aws/1.2.5/",
 				Tooltip: "hashicorp/aws Documentation",
 			},
 		},

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"

--- a/schema/schema_merge_remote_state_ds.go
+++ b/schema/schema_merge_remote_state_ds.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
 	"github.com/opentofu/opentofu-schema/module"

--- a/schema/schema_merge_remote_state_ds.go
+++ b/schema/schema_merge_remote_state_ds.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
 	"github.com/opentofu/opentofu-schema/module"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/schema/schema_merge_test.go
+++ b/schema/schema_merge_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfjson "github.com/hashicorp/terraform-json"
-	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/earlydecoder"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
 	"github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -174,7 +174,7 @@ func TestSchemaMerger_SchemaForModule_providerNameMatch(t *testing.T) {
 		ps: &tfjson.ProviderSchemas{
 			FormatVersion: "1.0",
 			Schemas: map[string]*tfjson.ProviderSchema{
-				"registry.terraform.io/hashicorp/data": {
+				"registry.opentofu.org/hashicorp/data": {
 					ConfigSchema: &tfjson.Schema{},
 					DataSourceSchemas: map[string]*tfjson.Schema{
 						"data": {
@@ -221,10 +221,10 @@ func TestSchemaMerger_SchemaForModule_providerNameMatch(t *testing.T) {
 						Attributes: map[string]*schema.AttributeSchema{},
 						Detail:     "hashicorp/data",
 						DocsLink: &schema.DocsLink{
-							URL:     "https://registry.terraform.io/providers/hashicorp/data/latest/docs",
+							URL:     "https://search.opentofu.org/provider/hashicorp/data/latest/",
 							Tooltip: "hashicorp/data Documentation",
 						},
-						HoverURL: "https://registry.terraform.io/providers/hashicorp/data/latest/docs",
+						HoverURL: "https://search.opentofu.org/provider/hashicorp/data/latest/",
 					},
 				},
 			},
@@ -235,7 +235,10 @@ func TestSchemaMerger_SchemaForModule_providerNameMatch(t *testing.T) {
 				},
 				Body: &schema.BodySchema{
 					Attributes: map[string]*schema.AttributeSchema{
-						"count": {Constraint: schema.LiteralType{Type: cty.Number}, IsOptional: true},
+						"count": {
+							Constraint: schema.LiteralType{Type: cty.Number},
+							IsOptional: true,
+						},
 					},
 				},
 				DependentBody: map[schema.SchemaKey]*schema.BodySchema{},
@@ -402,10 +405,10 @@ func TestSchemaMerger_SchemaForModule_twiceMerged(t *testing.T) {
 	mergedSchema, err := sm.SchemaForModule(&module.Meta{
 		Path: "testdata",
 		ProviderReferences: map[module.ProviderRef]tfaddr.Provider{
-			{LocalName: "hashicup"}: addr.NewDefaultProvider("hashicup"),
+			{LocalName: "hashicups"}: addr.NewDefaultProvider("hashicups"),
 		},
 		ProviderRequirements: map[tfaddr.Provider]version.Constraints{
-			addr.NewDefaultProvider("hashicup"): vc,
+			addr.NewDefaultProvider("hashicups"): vc,
 		},
 	})
 	if err != nil {
@@ -413,16 +416,16 @@ func TestSchemaMerger_SchemaForModule_twiceMerged(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(expectedMergedSchema_v015, mergedSchema, ctydebug.CmpOptions); diff != "" {
-		t.Fatalf("schema differs: %s", diff)
+		t.Fatalf("schema differs on first merge: %s", diff)
 	}
 
 	newMergedSchema, err := sm.SchemaForModule(&module.Meta{
 		Path: "testdata",
 		ProviderReferences: map[module.ProviderRef]tfaddr.Provider{
-			{LocalName: "hcc"}: addr.NewDefaultProvider("hashicup"),
+			{LocalName: "hcc"}: addr.NewDefaultProvider("hashicups"),
 		},
 		ProviderRequirements: map[tfaddr.Provider]version.Constraints{
-			addr.NewDefaultProvider("hashicup"): vc,
+			addr.NewDefaultProvider("hashicups"): vc,
 		},
 	})
 	if err != nil {
@@ -430,7 +433,7 @@ func TestSchemaMerger_SchemaForModule_twiceMerged(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(expectedMergedSchema_v015_aliased, newMergedSchema, ctydebug.CmpOptions); diff != "" {
-		t.Fatalf("schema differs: %s", diff)
+		t.Fatalf("schema differs on second merge: %s", diff)
 	}
 }
 
@@ -731,7 +734,7 @@ func (m *testRegistryModuleReaderStruct) DeclaredModuleCalls(modPath string) (ma
 		"remote-example": {
 			LocalName:     "remote-example",
 			RawSourceAddr: "namespace/foo/bar",
-			SourceAddr:    tfaddr.MustParseModuleSource("registry.terraform.io/namespace/foo/bar"),
+			SourceAddr:    tfaddr.MustParseModuleSource("registry.opentofu.org/namespace/foo/bar"),
 		},
 	}, nil
 }
@@ -752,7 +755,7 @@ func (m *testRegistryModuleReaderStruct) LocalModuleMeta(modPath string) (*modul
 }
 
 func (m *testRegistryModuleReaderStruct) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
-	if normalizedSource == "registry.terraform.io/namespace/foo/bar" {
+	if normalizedSource == "registry.opentofu.org/namespace/foo/bar" {
 		return filepath.Join(".terraform", "modules", "remote-example"), true
 	}
 	return "", false

--- a/schema/schema_merge_test.go
+++ b/schema/schema_merge_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfjson "github.com/hashicorp/terraform-json"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/opentofu/opentofu-schema/earlydecoder"
 	"github.com/opentofu/opentofu-schema/internal/addr"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -36,9 +36,9 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 					Detail:     "hashicorp/null",
-					HoverURL:   "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+					HoverURL:   "https://search.opentofu.org/provider/hashicorp/null/latest/",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
 						Tooltip: "hashicorp/null Documentation",
 					},
 				},
@@ -46,9 +46,9 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 					Detail:     "hashicorp/random",
-					HoverURL:   "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+					HoverURL:   "https://search.opentofu.org/provider/hashicorp/random/latest/",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/",
 						Tooltip: "hashicorp/random Documentation",
 					},
 				},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -33,13 +33,13 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 			},
 			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
 				`{"labels":[{"index":0,"value":"grafana"}]}`: {
-					Detail:   "grafana/grafana",
-					HoverURL: "https://registry.terraform.io/providers/grafana/grafana/latest/docs",
+					Detail: "grafana/grafana",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/grafana/grafana/latest/docs",
+						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/",
 						Tooltip: "grafana/grafana Documentation",
 					},
-					Blocks: map[string]*schema.BlockSchema{},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/",
+					Blocks:   map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{
 						"auth": {
 							Description: lang.MarkupContent{
@@ -62,9 +62,9 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 				},
 				`{"labels":[{"index":0,"value":"null"}]}`: {
 					Detail:   "hashicorp/null",
-					HoverURL: "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
 						Tooltip: "hashicorp/null Documentation",
 					},
 					Blocks:     map[string]*schema.BlockSchema{},
@@ -72,9 +72,9 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 				},
 				`{"labels":[{"index":0,"value":"rand"}]}`: {
 					Detail:   "hashicorp/random",
-					HoverURL: "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/",
 						Tooltip: "hashicorp/random Documentation",
 					},
 					Blocks:     map[string]*schema.BlockSchema{},

--- a/schema/schema_merge_v015_aliased_test.go
+++ b/schema/schema_merge_v015_aliased_test.go
@@ -35,7 +35,7 @@ var expectedMergedSchema_v015_aliased = &schema.BodySchema{
 				},
 			},
 			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
-				`{"labels":[{"index":0,"value":"hashicup_test"}],"attrs":[{"name":"provider","expr":{"addr":"hcc"}}]}`: {
+				`{"labels":[{"index":0,"value":"hashicups_test"}],"attrs":[{"name":"provider","expr":{"addr":"hcc"}}]}`: {
 					Blocks: map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{
 						"backend": {
@@ -172,7 +172,7 @@ var expectedMergedSchema_v015_aliased = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 						},
 					},
-					Detail: "hashicorp/hashicup",
+					Detail: "hashicorp/hashicups",
 				},
 			},
 		},
@@ -196,12 +196,12 @@ var expectedMergedSchema_v015_aliased = &schema.BodySchema{
 				`{"labels":[{"index":0,"value":"hcc"}]}`: {
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
-					Detail:     "hashicorp/hashicup",
-					HoverURL:   "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
+					Detail:     "hashicorp/hashicups",
 					DocsLink: &schema.DocsLink{
-						URL:     "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
-						Tooltip: "hashicorp/hashicup Documentation",
+						URL:     "https://search.opentofu.org/provider/hashicorp/hashicups/latest/",
+						Tooltip: "hashicorp/hashicups Documentation",
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/hashicups/latest/",
 				},
 			},
 		},

--- a/schema/schema_merge_v015_test.go
+++ b/schema/schema_merge_v015_test.go
@@ -45,7 +45,7 @@ var data = schema.BlockSchema{
 		},
 	},
 	DependentBody: map[schema.SchemaKey]*schema.BodySchema{
-		`{"labels":[{"index":0,"value":"hashicup_test"}],"attrs":[{"name":"provider","expr":{"addr":"hashicup"}}]}`: {
+		`{"labels":[{"index":0,"value":"hashicups_test"}],"attrs":[{"name":"provider","expr":{"addr":"hashicups"}}]}`: {
 			Blocks: map[string]*schema.BlockSchema{},
 			Attributes: map[string]*schema.AttributeSchema{
 				"backend": {
@@ -182,9 +182,9 @@ var data = schema.BlockSchema{
 					Constraint: schema.AnyExpression{OfType: cty.String},
 				},
 			},
-			Detail: "hashicorp/hashicup",
+			Detail: "hashicorp/hashicups",
 		},
-		`{"labels":[{"index":0,"value":"hashicup_test"}]}`: {
+		`{"labels":[{"index":0,"value":"hashicups_test"}]}`: {
 			Blocks: map[string]*schema.BlockSchema{},
 			Attributes: map[string]*schema.AttributeSchema{
 				"backend": {
@@ -321,7 +321,7 @@ var data = schema.BlockSchema{
 					Constraint: schema.AnyExpression{OfType: cty.String},
 				},
 			},
-			Detail: "hashicorp/hashicup",
+			Detail: "hashicorp/hashicups",
 		},
 	},
 }
@@ -340,14 +340,14 @@ var provider = schema.BlockSchema{
 		},
 	},
 	DependentBody: map[schema.SchemaKey]*schema.BodySchema{
-		`{"labels":[{"index":0,"value":"hashicup"}]}`: {
+		`{"labels":[{"index":0,"value":"hashicups"}]}`: {
 			Blocks:     map[string]*schema.BlockSchema{},
 			Attributes: map[string]*schema.AttributeSchema{},
-			Detail:     "hashicorp/hashicup",
-			HoverURL:   "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
+			Detail:     "hashicorp/hashicups",
+			HoverURL:   "https://search.opentofu.org/provider/hashicorp/hashicups/latest/",
 			DocsLink: &schema.DocsLink{
-				URL:     "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
-				Tooltip: "hashicorp/hashicup Documentation",
+				URL:     "https://search.opentofu.org/provider/hashicorp/hashicups/latest/",
+				Tooltip: "hashicorp/hashicups Documentation",
 			},
 		},
 	},
@@ -512,6 +512,9 @@ var expectedRemoteModuleSchema = &schema.BlockSchema{
 					},
 				},
 			}}): {
+			DocsLink: &schema.DocsLink{
+				URL: "https://search.opentofu.org/module/namespace/foo/bar/latest",
+			},
 			TargetableAs: []*schema.Targetable{
 				{
 					Address: lang.Address{
@@ -524,7 +527,6 @@ var expectedRemoteModuleSchema = &schema.BlockSchema{
 				},
 			},
 			ImpliedOrigins: schema.ImpliedOrigins{},
-			DocsLink:       &schema.DocsLink{URL: "https://registry.terraform.io/modules/namespace/foo/bar/latest"},
 			Attributes: map[string]*schema.AttributeSchema{
 				"test": {
 					Description: lang.PlainText("test var"),

--- a/schema/testdata/provider-schemas-0.13.json
+++ b/schema/testdata/provider-schemas-0.13.json
@@ -1,7 +1,7 @@
 {
     "format_version": "0.1",
     "provider_schemas": {
-        "registry.terraform.io/grafana/grafana": {
+        "registry.opentofu.org/grafana/grafana": {
             "provider": {
                 "version": 0,
                 "block": {
@@ -525,7 +525,7 @@
                 }
             }
         },
-        "registry.terraform.io/hashicorp/null": {
+        "registry.opentofu.org/hashicorp/null": {
             "provider": {
                 "version": 0,
                 "block": {
@@ -607,7 +607,7 @@
                 }
             }
         },
-        "registry.terraform.io/hashicorp/random": {
+        "registry.opentofu.org/hashicorp/random": {
             "provider": {
                 "version": 0,
                 "block": {

--- a/schema/testdata/provider-schemas-0.15.json
+++ b/schema/testdata/provider-schemas-0.15.json
@@ -1,7 +1,7 @@
 {
     "format_version": "0.1",
     "provider_schemas": {
-        "registry.terraform.io/hashicorp/hashicup": {
+        "registry.opentofu.org/hashicorp/hashicups": {
             "provider": {
                 "version": 0,
                 "block": {
@@ -10,7 +10,7 @@
                 }
             },
             "data_source_schemas": {
-                "hashicup_test": {
+                "hashicups_test": {
                     "version": 0,
                     "block": {
                         "attributes": {

--- a/schema/testdata/test-config-0.15.tf
+++ b/schema/testdata/test-config-0.15.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    hashicup = {
-      source  = "hashicorp/hashicup"
+    hashicups = {
+      source  = "hashicorp/hashicups"
       version = "0.0.0"
     }
   }


### PR DESCRIPTION
Resolves #16 
Relates to https://github.com/opentofu/opentofu-ls/pull/14

Sorry in advance for the long PR, but if it was split, we would need to review tons of code that would be deleted and re-added.

This PR implements the following:

1. Changes references from `github.com/hashicorp/terraform-registry-address` to `github.com/opentofu/registry-address`;
1. `go mod tidy` to use dependencies of `github.com/opentofu/registry-address`;
2. Adapted schema to use `registry.opentofu.org` in its `HoverURL` and `DocsLink`;
4. `hashicup` is not on OpenTofu's registry, while `hashicups` is: https://search.opentofu.org/provider/hashicorp/hashicups/latest/