### PR TITLE
improving docslink tests

### DIFF
--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -325,6 +325,7 @@ func TestSchemaForDependentModuleBlock_Target(t *testing.T) {
 }
 
 func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		name           string
 		meta           *module.Meta
@@ -457,13 +458,15 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		depSchema, err := schemaForDependentModuleBlock(tc.module, tc.meta)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(tc.expectedSchema, depSchema, ctydebug.CmpOptions); diff != "" {
-			t.Fatalf("schema mismatch: %s", diff)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			depSchema, err := schemaForDependentModuleBlock(tc.module, tc.meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expectedSchema, depSchema, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("schema mismatch: %s", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Relates to #16

While fixing the test suite for using opentofu-registry, I've noticed that when one of the testcases for DocsLink were failing, it wasn't reported which one was failing. So I've used the same pattern we use in other repos in order to see the name of the failing test case.

Parallelization of these tests were added too.

Notice the test case after the test's name:

<img width="1004" alt="Screenshot 2025-04-30 at 16 41 40" src="https://github.com/user-attachments/assets/8af06907-94db-453c-8472-06c24535667a" />

