### PR TITLE
add `for-each` support in `provider` block - tofu 1.9

### DIFF
--- a/internal/schema/1.9/root.go
+++ b/internal/schema/1.9/root.go
@@ -36,5 +36,9 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs.Blocks["removed"].Body.Blocks["connection"] = v012_mod.ConnectionBlock(v)
 	bs.Blocks["removed"].Body.Blocks["connection"].DependentBody = v1_3_mod.ConnectionDependentBodies(v)
 
+	bs.Blocks["provider"].Body.Extensions = &schema.BodyExtensions{
+		ForEach: true,
+	}
+
 	return bs
 }


### PR DESCRIPTION
Relates to https://github.com/opentofu/tofu-ls/issues/8

Adding `for_each` attribute to `provider` block starting on tofu `v1.9.x`.