### PR TITLE
upgrade  `setup-go` action to 5.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: ".go-version"
       -


### PR DESCRIPTION
We're having the same problem on our CI/CD for this repo that we were experiencing earlier in other repos. It's basically the same issue from https://github.com/opentofu/tofu-ls/issues/63 and https://github.com/opentofu/vscode-opentofu/pull/20.