### PR TITLE
Fix legacy namespace and adds HoverURL

### DIFF
--- a/schema/resource_schema.go
+++ b/schema/resource_schema.go
@@ -27,15 +27,22 @@ func (bs *SchemaMerger) mergeResourceSchema(bSchema *schema.BodySchema, rName st
 		},
 	}
 
-	// In OpenTofu's Search Registry, we don't save the resource prefix on the URL, example:
-	// random_uuid becomes uuid on the URL
-	if providerAddr.Namespace != "" && !providerAddr.IsLegacy() {
+	namespace := providerAddr.Namespace
+	if providerAddr.IsLegacy() {
+		// When namespaces are legacy, we assume their namespace is hashicorp
+		namespace = "hashicorp"
+	}
+
+	if namespace != "" {
+		// In OpenTofu's Search Registry, we don't save the resource prefix on the URL, example:
+		// random_uuid becomes uuid on the URL
 		registryName := rName[len(providerAddr.Type)+1:]
-		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/resources/%s", providerAddr.Namespace, providerAddr.Type, registryName)
+		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/resources/%s", namespace, providerAddr.Type, registryName)
 		rSchema.DocsLink = &schema.DocsLink{
 			URL:     docsUrl,
-			Tooltip: fmt.Sprintf("%s/%s/%s Documentation", providerAddr.Namespace, providerAddr.Type, rName),
+			Tooltip: fmt.Sprintf("%s/%s/%s Documentation", namespace, providerAddr.Type, rName),
 		}
+		rSchema.HoverURL = docsUrl
 	}
 
 	bSchema.Blocks["resource"].DependentBody[schema.NewSchemaKey(depKeys)] = rSchema

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -99,6 +99,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+						Tooltip: "hashicorp/null/null_resource Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"null_resource"}],"attrs":[{"name":"provider","expr":{"addr":"null"}}]}`: {
 					Detail: "hashicorp/null",
@@ -122,6 +127,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+						Tooltip: "hashicorp/null/null_resource Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"null_resource"}],"attrs":[{"name":"provider","expr":{"addr":"null.foobar"}}]}`: {
 					Detail: "hashicorp/null",
@@ -144,6 +154,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
+						Tooltip: "hashicorp/null/null_resource Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_id"}]}`: {
@@ -216,6 +231,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
+						Tooltip: "hashicorp/random/random_id Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_integer"}]}`: {
 					Detail: "hashicorp/random",
@@ -270,6 +290,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
+						Tooltip: "hashicorp/random/random_integer Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_password"}]}`: {
@@ -383,6 +408,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
+						Tooltip: "hashicorp/random/random_password Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_pet"}]}`: {
 					Detail: "hashicorp/random",
@@ -429,6 +459,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
+						Tooltip: "hashicorp/random/random_pet Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_shuffle"}]}`: {
@@ -494,6 +529,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
+						Tooltip: "hashicorp/random/random_shuffle Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_string"}]}`: {
@@ -606,6 +646,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
+						Tooltip: "hashicorp/random/random_string Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_uuid"}]}`: {
 					Detail: "hashicorp/random",
@@ -636,6 +681,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsComputed: true,
 							Constraint: schema.AnyExpression{OfType: cty.String},
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
+						Tooltip: "hashicorp/random/random_uuid Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_id"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
@@ -708,6 +758,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
+						Tooltip: "hashicorp/random/random_id Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_integer"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
 					Detail: "hashicorp/random",
@@ -762,6 +817,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
+						Tooltip: "hashicorp/random/random_integer Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_password"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
@@ -875,6 +935,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
+						Tooltip: "hashicorp/random/random_password Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_pet"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
 					Detail: "hashicorp/random",
@@ -921,6 +986,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
+						Tooltip: "hashicorp/random/random_pet Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_shuffle"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
@@ -986,6 +1056,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							Constraint: schema.AnyExpression{OfType: cty.String},
 							IsOptional: true,
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
+						Tooltip: "hashicorp/random/random_shuffle Documentation",
 					},
 				},
 				`{"labels":[{"index":0,"value":"random_string"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
@@ -1098,6 +1173,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
+						Tooltip: "hashicorp/random/random_string Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random_uuid"}],"attrs":[{"name":"provider","expr":{"addr":"random"}}]}`: {
 					Detail: "hashicorp/random",
@@ -1128,6 +1208,11 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 							IsComputed: true,
 							Constraint: schema.AnyExpression{OfType: cty.String},
 						},
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
+						Tooltip: "hashicorp/random/random_uuid Documentation",
 					},
 				},
 			},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -149,6 +149,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/alert_notification",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/alert_notification",
 						Tooltip: "grafana/grafana/grafana_alert_notification Documentation",
@@ -176,6 +177,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/dashboard",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/dashboard",
 						Tooltip: "grafana/grafana/grafana_dashboard Documentation",
@@ -396,6 +398,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/data_source",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/data_source",
 						Tooltip: "grafana/grafana/grafana_data_source Documentation",
@@ -419,6 +422,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/folder",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/folder",
 						Tooltip: "grafana/grafana/grafana_folder Documentation",
@@ -477,6 +481,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/organization",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/organization",
 						Tooltip: "grafana/grafana/grafana_organization Documentation",
@@ -513,6 +518,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/team",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/team",
 						Tooltip: "grafana/grafana/grafana_team Documentation",
@@ -545,6 +551,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsSensitive: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/user",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/user",
 						Tooltip: "grafana/grafana/grafana_user Documentation",
@@ -596,6 +603,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/alert_notification",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/alert_notification",
 						Tooltip: "grafana/grafana/grafana_alert_notification Documentation",
@@ -623,6 +631,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/dashboard",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/dashboard",
 						Tooltip: "grafana/grafana/grafana_dashboard Documentation",
@@ -843,6 +852,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/data_source",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/data_source",
 						Tooltip: "grafana/grafana/grafana_data_source Documentation",
@@ -866,6 +876,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/folder",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/folder",
 						Tooltip: "grafana/grafana/grafana_folder Documentation",
@@ -924,6 +935,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsOptional: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/organization",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/organization",
 						Tooltip: "grafana/grafana/grafana_organization Documentation",
@@ -960,6 +972,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsComputed: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/team",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/team",
 						Tooltip: "grafana/grafana/grafana_team Documentation",
@@ -992,6 +1005,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 							IsSensitive: true,
 						},
 					},
+					HoverURL: "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/user",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/grafana/grafana/latest/docs/resources/user",
 						Tooltip: "grafana/grafana/grafana_user Documentation",
@@ -1025,6 +1039,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The `null_resource` resource implements the standard resource lifecycle but takes no further action.\n\nThe `triggers` argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 						Tooltip: "hashicorp/null/null_resource Documentation",
@@ -1058,6 +1073,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The `null_resource` resource implements the standard resource lifecycle but takes no further action.\n\nThe `triggers` argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 						Tooltip: "hashicorp/null/null_resource Documentation",
@@ -1091,6 +1107,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The `null_resource` resource implements the standard resource lifecycle but takes no further action.\n\nThe `triggers` argument allows specifying an arbitrary set of values that, when changed, will cause the resource to be replaced.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/docs/resources/resource",
 						Tooltip: "hashicorp/null/null_resource Documentation",
@@ -1172,6 +1189,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "\nThe resource `random_id` generates random numbers that are intended to be\nused as unique identifiers for other resources.\n\nThis resource *does* use a cryptographic random number generator in order\nto minimize the chance of collisions, making the results of this resource\nwhen a 16-byte identifier is requested of equivalent uniqueness to a\ntype-4 UUID.\n\nThis resource can be used in conjunction with resources that have\nthe `create_before_destroy` lifecycle flag set to avoid conflicts with\nunique names during the brief period where both the old and new resources\nexist concurrently.\n",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id",
 						Tooltip: "hashicorp/random/random_id Documentation",
@@ -1237,6 +1255,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The resource `random_integer` generates random values from a given range, described by the `min` and `max` attributes of a given resource.\n\nThis resource can be used in conjunction with resources that have the `create_before_destroy` lifecycle flag set, to avoid conflicts with unique names during the brief period where both the old and new resources exist concurrently.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/integer",
 						Tooltip: "hashicorp/random/random_integer Documentation",
@@ -1359,6 +1378,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "Identical to [random_string](string.html) with the exception that the result is treated as sensitive and, thus, _not_ displayed in console output.\n\nThis resource *does* use a cryptographic random number generator.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/password",
 						Tooltip: "hashicorp/random/random_password Documentation",
@@ -1416,6 +1436,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The resource `random_pet` generates random pet names that are intended to be used as unique identifiers for other resources.\n\nThis resource can be used in conjunction with resources that have the `create_before_destroy` lifecycle flag set, to avoid conflicts with unique names during the brief period where both the old and new resources exist concurrently.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/pet",
 						Tooltip: "hashicorp/random/random_pet Documentation",
@@ -1491,6 +1512,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The resource `random_shuffle` generates a random permutation of a list of strings given as an argument.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/shuffle",
 						Tooltip: "hashicorp/random/random_shuffle Documentation",
@@ -1612,6 +1634,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The resource `random_string` generates a random permutation of alphanumeric characters and optionally special characters.\n\nThis resource *does* use a cryptographic random number generator.\n\nHistorically this resource's intended usage has been ambiguous as the original example used it in a password. For backwards compatibility it will continue to exist. For unique ids please use [random_id](id.html), for sensitive random values please use [random_password](password.html).",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string",
 						Tooltip: "hashicorp/random/random_string Documentation",
@@ -1653,6 +1676,7 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 						Value: "The resource `random_uuid` generates random uuid string that is intended to be used as unique identifiers for other resources.\n\nThis resource uses [hashicorp/go-uuid](https://github.com/hashicorp/go-uuid) to generate a UUID-formatted string for use with services needed a unique string identifier.",
 						Kind:  lang.MarkdownKind,
 					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/uuid",
 						Tooltip: "hashicorp/random/random_uuid Documentation",


### PR DESCRIPTION
Relates to https://github.com/opentofu/vscode-opentofu/issues/6

While integrating with `vscode-opentofu`, I noticed I understood wrong where DocsLink is used. For the purpose of the work I was doing, I should've been using `HoverURL`. This is what is used when hovering the element.

Screenshot of integration:

<img width="654" alt="Screenshot 2025-06-10 at 16 34 34" src="https://github.com/user-attachments/assets/f37aea71-eecf-485a-9082-5f90af9dd0a7" />

DocsLink is used in another view of VSCode:

<img width="425" alt="Screenshot 2025-06-10 at 16 34 54" src="https://github.com/user-attachments/assets/62be8cee-37ac-424e-8f13-32b328633146" />


This PR fixes another misunderstanding. When provider addresses have namespaces using `hashicorp`, they are mostly being treated as LegacyAddresses in our code:

https://github.com/opentofu/registry-address/blob/901b9ae4061a6e83e7db96e71b8d7088294930b3/provider.go#L166

So now, if we have any LegacyAddr, we use the namespace as `hashicorp` both on the HoverURL and the DocsLink.