### PR TITLE
Making provider alias as a reference and targetable

### DIFF
--- a/internal/schema/0.12/resource_block.go
+++ b/internal/schema/0.12/resource_block.go
@@ -54,7 +54,7 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 			},
 			Attributes: map[string]*schema.AttributeSchema{
 				"provider": {
-					Constraint:             schema.Reference{OfScopeId: refscope.ProviderScope},
+					Constraint:             schema.AnyExpression{OfType: cty.DynamicPseudoType},
 					IsOptional:             true,
 					Description:            lang.Markdown("Reference to a `provider` configuration block, e.g. `mycloud.west` or `mycloud`"),
 					IsDepKey:               true,

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
+	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
 	tfaddr "github.com/opentofu/registry-address"
@@ -116,6 +117,11 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 			}
 			if localRef.Alias != "" {
 				providerAddr = append(providerAddr, lang.AttrStep{Name: localRef.Alias})
+				mergedSchema.Blocks["provider"].Body.TargetableAs = append(mergedSchema.Blocks["provider"].Body.TargetableAs, &schema.Targetable{
+					Address: providerAddr,
+					ScopeId: refscope.ProviderScope,
+					AsType:  cty.DynamicPseudoType,
+				})
 			}
 
 			for rName, rSchema := range pSchema.Resources {

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
+	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -28,6 +29,16 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					"alias": {
 						Constraint: schema.LiteralType{Type: cty.String},
 						IsOptional: true,
+					},
+				},
+				TargetableAs: schema.Targetables{
+					{
+						Address: lang.Address{
+							lang.RootStep{Name: "null"},
+							lang.AttrStep{Name: "foobar"},
+						},
+						ScopeId: refscope.ProviderScope,
+						AsType:  cty.DynamicPseudoType,
 					},
 				},
 			},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
+	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -28,6 +29,16 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					"alias": {
 						Constraint: schema.LiteralType{Type: cty.String},
 						IsOptional: true,
+					},
+				},
+				TargetableAs: schema.Targetables{
+					{
+						Address: lang.Address{
+							lang.RootStep{Name: "null"},
+							lang.AttrStep{Name: "foobar"},
+						},
+						ScopeId: refscope.ProviderScope,
+						AsType:  cty.DynamicPseudoType,
 					},
 				},
 			},


### PR DESCRIPTION
Relates to https://github.com/opentofu/tofu-ls/issues/8

This PR is constituted of two parts:

# 1 - Adding `provider.alias[each.key]` as an origin

This code is responsible for adding `provider.alias[each.key]` as targets:

```
Constraint: schema.OneOf{
						schema.AnyExpression{OfType: cty.DynamicPseudoType},
						schema.Reference{OfScopeId: refscope.ProviderScope},
					},
```

This constraint is used on the resource block. When we're using `provider.alias` notation, the constraint is the type of `schema.Reference{OfScopeId: refscope.ProviderScope}`, but when using in the notation above for collections, the constraint is not added. The code path to be achieved is this one:

https://github.com/hashicorp/hcl-lang/blob/main/decoder/expr_any_ref_origins.go#L179-186

<img width="917" alt="Screenshot 2025-06-16 at 11 29 48" src="https://github.com/user-attachments/assets/d37a1a60-e5d8-407b-800e-c543500df557" />

That way we can add `aws.by_region` as a origin reference.


# 2 - Making the `aws_by_region` targetable

Just adding as a origin above is not enough. We need to make this range targetable, so when the target like `aws.by_region` is clicked, we can arrive at the desired provider. This code is tested in this part here:

https://github.com/hashicorp/hcl-lang/blob/63c091d281a8c19923dd08aba518522ae05a2ed7/reference/targets.go#L120

So it tests if the address matches, but if the Targetable region is the same, if yes, we can click to go to the reference.



# Demo integrated with the VSCode Extension

`aws.by_region` reference the expected block while `aws.us_west_1` doesn't work since it's a different block.

https://github.com/user-attachments/assets/23addda4-4648-4dd8-99a6-79ad75125d98


