### PR TITLE
Fixes provider alias references and definition

### DIFF
--- a/internal/schema/0.12/module_block.go
+++ b/internal/schema/0.12/module_block.go
@@ -65,10 +65,14 @@ func moduleBlockSchema() *schema.BlockSchema {
 					},
 				},
 				"providers": {
-					Constraint: schema.Map{
-						Name: "map of provider references",
-						Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
+					Constraint: schema.OneOf{
+						schema.AnyExpression{OfType: cty.DynamicPseudoType},
+						schema.Map{
+							Name: "map of provider references",
+							Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
+						},
 					},
+					IsDepKey:    true,
 					IsOptional:  true,
 					Description: lang.Markdown("Explicit mapping of providers which the module uses"),
 				},

--- a/internal/schema/0.12/provider_block.go
+++ b/internal/schema/0.12/provider_block.go
@@ -24,6 +24,9 @@ func providerBlockSchema(v *version.Version) *schema.BlockSchema {
 			FriendlyName: "provider",
 			ScopeId:      refscope.ProviderScope,
 			AsReference:  true,
+			AsTypeOf: &schema.BlockAsTypeOf{
+				AttributeExpr: "type",
+			},
 		},
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
 		Labels: []*schema.LabelSchema{

--- a/internal/schema/0.13/module_block.go
+++ b/internal/schema/0.13/module_block.go
@@ -70,10 +70,14 @@ func moduleBlockSchema() *schema.BlockSchema {
 					},
 				},
 				"providers": {
-					Constraint: schema.Map{
-						Name: "map of provider references",
-						Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
+					Constraint: schema.OneOf{
+						schema.AnyExpression{OfType: cty.DynamicPseudoType},
+						schema.Map{
+							Name: "map of provider references",
+							Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
+						},
 					},
+					IsDepKey:    true,
 					IsOptional:  true,
 					Description: lang.Markdown("Explicit mapping of providers which the module uses"),
 				},

--- a/internal/schema/0.13/provider_block.go
+++ b/internal/schema/0.13/provider_block.go
@@ -24,6 +24,9 @@ func providerBlockSchema() *schema.BlockSchema {
 			FriendlyName: "provider",
 			ScopeId:      refscope.ProviderScope,
 			AsReference:  true,
+			AsTypeOf: &schema.BlockAsTypeOf{
+				AttributeExpr: "type",
+			},
 		},
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
 		Labels: []*schema.LabelSchema{

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
-	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
 	tfaddr "github.com/opentofu/registry-address"
@@ -117,24 +116,6 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 			}
 			if localRef.Alias != "" {
 				providerAddr = append(providerAddr, lang.AttrStep{Name: localRef.Alias})
-				depKeys := schema.DependencyKeys{
-					Attributes: []schema.AttributeDependent{
-						{
-							Name: "alias",
-							Expr: schema.ExpressionValue{
-								Address: providerAddr,
-							},
-						},
-					},
-				}
-				mergedSchema.Blocks["provider"].DependentBody[schema.NewSchemaKey(depKeys)] = pSchema.Provider
-				mergedSchema.Blocks["provider"].DependentBody[schema.NewSchemaKey(depKeys)].TargetableAs = schema.Targetables{
-					{
-						Address: providerAddr,
-						ScopeId: refscope.ProviderScope,
-						AsType:  cty.DynamicPseudoType,
-					},
-				}
 			}
 
 			for rName, rSchema := range pSchema.Resources {

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
-	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -31,16 +30,6 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 						IsOptional: true,
 					},
 				},
-				TargetableAs: schema.Targetables{
-					{
-						Address: lang.Address{
-							lang.RootStep{Name: "null"},
-							lang.AttrStep{Name: "foobar"},
-						},
-						ScopeId: refscope.ProviderScope,
-						AsType:  cty.DynamicPseudoType,
-					},
-				},
 			},
 			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
 				`{"labels":[{"index":0,"value":"null"}]}`: {
@@ -52,6 +41,16 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
 						Tooltip: "hashicorp/null Documentation",
 					},
+					TargetableAs: schema.Targetables{
+						{
+							Address: lang.Address{
+								lang.RootStep{Name: "null"},
+								lang.AttrStep{Name: "foobar"},
+							},
+							ScopeId: "provider",
+							AsType:  cty.DynamicPseudoType,
+						},
+					},
 				},
 				`{"labels":[{"index":0,"value":"random"}]}`: {
 					Blocks:     map[string]*schema.BlockSchema{},
@@ -61,6 +60,26 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/",
 						Tooltip: "hashicorp/random Documentation",
+					},
+				},
+				`{"attrs":[{"name":"alias","expr":{"addr":"null.foobar"}}]}`: {
+					Blocks:     map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{},
+					Detail:     "hashicorp/null",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
+						Tooltip: "hashicorp/null Documentation",
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/",
+					TargetableAs: schema.Targetables{
+						{
+							Address: lang.Address{
+								lang.RootStep{Name: "null"},
+								lang.AttrStep{Name: "foobar"},
+							},
+							ScopeId: "provider",
+							AsType:  cty.DynamicPseudoType,
+						},
 					},
 				},
 			},

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -41,16 +41,6 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
 						Tooltip: "hashicorp/null Documentation",
 					},
-					TargetableAs: schema.Targetables{
-						{
-							Address: lang.Address{
-								lang.RootStep{Name: "null"},
-								lang.AttrStep{Name: "foobar"},
-							},
-							ScopeId: "provider",
-							AsType:  cty.DynamicPseudoType,
-						},
-					},
 				},
 				`{"labels":[{"index":0,"value":"random"}]}`: {
 					Blocks:     map[string]*schema.BlockSchema{},
@@ -60,26 +50,6 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					DocsLink: &schema.DocsLink{
 						URL:     "https://search.opentofu.org/provider/hashicorp/random/latest/",
 						Tooltip: "hashicorp/random Documentation",
-					},
-				},
-				`{"attrs":[{"name":"alias","expr":{"addr":"null.foobar"}}]}`: {
-					Blocks:     map[string]*schema.BlockSchema{},
-					Attributes: map[string]*schema.AttributeSchema{},
-					Detail:     "hashicorp/null",
-					DocsLink: &schema.DocsLink{
-						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
-						Tooltip: "hashicorp/null Documentation",
-					},
-					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/",
-					TargetableAs: schema.Targetables{
-						{
-							Address: lang.Address{
-								lang.RootStep{Name: "null"},
-								lang.AttrStep{Name: "foobar"},
-							},
-							ScopeId: "provider",
-							AsType:  cty.DynamicPseudoType,
-						},
 					},
 				},
 			},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -69,16 +69,6 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
-					TargetableAs: schema.Targetables{
-						{
-							Address: lang.Address{
-								lang.RootStep{Name: "null"},
-								lang.AttrStep{Name: "foobar"},
-							},
-							ScopeId: "provider",
-							AsType:  cty.DynamicPseudoType,
-						},
-					},
 				},
 				`{"labels":[{"index":0,"value":"rand"}]}`: {
 					Detail:   "hashicorp/random",
@@ -89,26 +79,6 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
-				},
-				`{"attrs":[{"name":"alias","expr":{"addr":"null.foobar"}}]}`: {
-					Blocks:     map[string]*schema.BlockSchema{},
-					Attributes: map[string]*schema.AttributeSchema{},
-					Detail:     "hashicorp/null",
-					DocsLink: &schema.DocsLink{
-						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
-						Tooltip: "hashicorp/null Documentation",
-					},
-					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/",
-					TargetableAs: schema.Targetables{
-						{
-							Address: lang.Address{
-								lang.RootStep{Name: "null"},
-								lang.AttrStep{Name: "foobar"},
-							},
-							ScopeId: "provider",
-							AsType:  cty.DynamicPseudoType,
-						},
-					},
 				},
 			},
 		},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/backends"
-	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
 	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -29,16 +28,6 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					"alias": {
 						Constraint: schema.LiteralType{Type: cty.String},
 						IsOptional: true,
-					},
-				},
-				TargetableAs: schema.Targetables{
-					{
-						Address: lang.Address{
-							lang.RootStep{Name: "null"},
-							lang.AttrStep{Name: "foobar"},
-						},
-						ScopeId: refscope.ProviderScope,
-						AsType:  cty.DynamicPseudoType,
 					},
 				},
 			},
@@ -80,6 +69,16 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
+					TargetableAs: schema.Targetables{
+						{
+							Address: lang.Address{
+								lang.RootStep{Name: "null"},
+								lang.AttrStep{Name: "foobar"},
+							},
+							ScopeId: "provider",
+							AsType:  cty.DynamicPseudoType,
+						},
+					},
 				},
 				`{"labels":[{"index":0,"value":"rand"}]}`: {
 					Detail:   "hashicorp/random",
@@ -90,6 +89,26 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
+				},
+				`{"attrs":[{"name":"alias","expr":{"addr":"null.foobar"}}]}`: {
+					Blocks:     map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{},
+					Detail:     "hashicorp/null",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://search.opentofu.org/provider/hashicorp/null/latest/",
+						Tooltip: "hashicorp/null Documentation",
+					},
+					HoverURL: "https://search.opentofu.org/provider/hashicorp/null/latest/",
+					TargetableAs: schema.Targetables{
+						{
+							Address: lang.Address{
+								lang.RootStep{Name: "null"},
+								lang.AttrStep{Name: "foobar"},
+							},
+							ScopeId: "provider",
+							AsType:  cty.DynamicPseudoType,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Relates to https://github.com/opentofu/vscode-opentofu/pull/61

This PR fixes the alias pointing to all the provider blocks. 
Previously I was adding this information to all the provider blocks. Now we're adding only to the right places, so the definition and references works as expected:

DEMO:


https://github.com/user-attachments/assets/44cf512d-f7c6-4c28-a550-6f091c59266c

There was another provider on this file, so the deduplication worked as expected.

# Support in providers for module

Adding support on the references for module blocks like that:

``` 
module "ai" {
  source = "./ai"

  providers = aws.by_region[each.key]
  for_each  = setsubtract(var.aws_active_regions, var.aws_disabled_regions)
}
```