### PR TITLE
Matching `removed` schema to OpenTofu

### DIFF
--- a/internal/schema/1.10/removed.go
+++ b/internal/schema/1.10/removed.go
@@ -1,0 +1,47 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2024 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	v012_mod "github.com/opentofu/opentofu-schema/internal/schema/0.12"
+	v1_3_mod "github.com/opentofu/opentofu-schema/internal/schema/1.3"
+	v1_4_mod "github.com/opentofu/opentofu-schema/internal/schema/1.4"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func patchRemovedBlock1_10(v *version.Version, bs *schema.BodySchema) {
+	bs.Blocks["removed"].Body.Blocks["lifecycle"] = &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations controlling the removal"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"destroy": {
+					Constraint:  schema.LiteralType{Type: cty.Bool},
+					IsRequired:  true,
+					Description: lang.Markdown("Whether OpenTofu will attempt to destroy the objects (`true`) or not, i.e. just remove from state (`false`)."),
+				},
+			},
+		},
+		MinItems: 0,
+		MaxItems: 1,
+	}
+
+	bs.Blocks["removed"].Body.Blocks["provisioner"] = v012_mod.ProvisionerBlock(v)
+	bs.Blocks["removed"].Body.Blocks["provisioner"].DependentBody = v1_4_mod.ProvisionerDependentBodies(v)
+	bs.Blocks["removed"].Body.Blocks["provisioner"].Body.Blocks["connection"].DependentBody = v1_3_mod.ConnectionDependentBodies(v)
+	bs.Blocks["removed"].Body.Blocks["provisioner"].Body.Attributes["when"] = &schema.AttributeSchema{
+		Constraint: schema.OneOf{
+			schema.Keyword{
+				Keyword:     "destroy",
+				Description: lang.Markdown("Run the provisioner when the resource is destroyed"),
+			},
+		},
+		IsOptional:  true,
+		Description: lang.Markdown("When to run the provisioner - `removed` resources can only be destroyed."),
+	}
+}

--- a/internal/schema/1.10/root.go
+++ b/internal/schema/1.10/root.go
@@ -18,5 +18,7 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs.Blocks["terraform"].Body.Blocks["encryption"] = patchEncryptionBlockSchema(
 		bs.Blocks["terraform"].Body.Blocks["encryption"],
 	)
+
+	patchRemovedBlock1_10(v, bs)
 	return bs
 }

--- a/internal/schema/1.7/removed.go
+++ b/internal/schema/1.7/removed.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/opentofu/opentofu-schema/internal/schema/refscope"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func removedBlock() *schema.BlockSchema {
@@ -27,22 +26,7 @@ func removedBlock() *schema.BlockSchema {
 					Description: lang.Markdown("Address of the module or resource to be removed"),
 				},
 			},
-			Blocks: map[string]*schema.BlockSchema{
-				"lifecycle": {
-					Description: lang.Markdown("Lifecycle customizations controlling the removal"),
-					Body: &schema.BodySchema{
-						Attributes: map[string]*schema.AttributeSchema{
-							"destroy": {
-								Constraint:  schema.LiteralType{Type: cty.Bool},
-								IsRequired:  true,
-								Description: lang.Markdown("Whether OpenTofu will attempt to destroy the objects (`true`) or not, i.e. just remove from state (`false`)."),
-							},
-						},
-					},
-					MinItems: 0,
-					MaxItems: 1,
-				},
-			},
+			Blocks: map[string]*schema.BlockSchema{},
 		},
 	}
 }

--- a/internal/schema/1.7/removed.go
+++ b/internal/schema/1.7/removed.go
@@ -39,7 +39,7 @@ func removedBlock() *schema.BlockSchema {
 							},
 						},
 					},
-					MinItems: 1,
+					MinItems: 0,
 					MaxItems: 1,
 				},
 			},

--- a/internal/schema/1.9/root.go
+++ b/internal/schema/1.9/root.go
@@ -7,31 +7,15 @@ package schema
 
 import (
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 
 	v012_mod "github.com/opentofu/opentofu-schema/internal/schema/0.12"
 	v1_3_mod "github.com/opentofu/opentofu-schema/internal/schema/1.3"
-	v1_4_mod "github.com/opentofu/opentofu-schema/internal/schema/1.4"
 	v1_8_mod "github.com/opentofu/opentofu-schema/internal/schema/1.8"
 )
 
 func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v1_8_mod.ModuleSchema(v)
-
-	bs.Blocks["removed"].Body.Blocks["provisioner"] = v012_mod.ProvisionerBlock(v)
-	bs.Blocks["removed"].Body.Blocks["provisioner"].DependentBody = v1_4_mod.ProvisionerDependentBodies(v)
-	bs.Blocks["removed"].Body.Blocks["provisioner"].Body.Blocks["connection"].DependentBody = v1_3_mod.ConnectionDependentBodies(v)
-	bs.Blocks["removed"].Body.Blocks["provisioner"].Body.Attributes["when"] = &schema.AttributeSchema{
-		Constraint: schema.OneOf{
-			schema.Keyword{
-				Keyword:     "destroy",
-				Description: lang.Markdown("Run the provisioner when the resource is destroyed"),
-			},
-		},
-		IsOptional:  true,
-		Description: lang.Markdown("When to run the provisioner - `removed` resources can only be destroyed."),
-	}
 
 	bs.Blocks["removed"].Body.Blocks["connection"] = v012_mod.ConnectionBlock(v)
 	bs.Blocks["removed"].Body.Blocks["connection"].DependentBody = v1_3_mod.ConnectionDependentBodies(v)


### PR DESCRIPTION
Relates to https://github.com/opentofu/tofu-ls/issues/85

- Making the `lifecycle` block optional on `removed` blocks.
- Moving `removed` block to OpenTofu 1.10 schema ([we didn't have on 1.7](https://github.com/opentofu/opentofu/commit/3c51831e5ca89c925806a7da8f6dd4831fb160ad))
- Removing `connection` block on `removed` block on 1.9.