### PR TITLE
remove any type for module/providers

### DIFF
--- a/internal/schema/0.13/module_block.go
+++ b/internal/schema/0.13/module_block.go
@@ -70,12 +70,9 @@ func moduleBlockSchema() *schema.BlockSchema {
 					},
 				},
 				"providers": {
-					Constraint: schema.OneOf{
-						schema.AnyExpression{OfType: cty.DynamicPseudoType},
-						schema.Map{
-							Name: "map of provider references",
-							Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
-						},
+					Constraint: schema.Map{
+						Name: "map of provider references",
+						Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
 					},
 					IsDepKey:    true,
 					IsOptional:  true,


### PR DESCRIPTION
While I've used any type to create a reference on the `providers` field for `module` blocks, the configuration I was testing was based in an invalid configuration:

```
module "name" {
  ...
  providers = aws.by_region[each.key]
  ...
}
```

This would show an error of "A static map expression is required.".  So I'm reverting back that code since with a valid configuration the references would work already as expected.