### PR TITLE
add reference support for complex type variables

### DIFF
--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -151,6 +151,8 @@ func typeCanBeBlocks(ty cty.Type) bool {
 	return (ty.IsListType() || ty.IsSetType()) && ty.ElementType().IsObjectType()
 }
 
+// blockSchemaForAttribute returns a block schema for the given attribute
+// if the attribute type is a list-of-object or set-of-object type.
 func blockSchemaForAttribute(attr *tfjson.SchemaAttribute) (*schema.BlockSchema, bool) {
 	if attr.AttributeType == cty.NilType {
 		return nil, false

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -281,6 +281,7 @@ func typeBelongsToProvider(typeName string, pRef tfmod.ProviderRef) bool {
 	return typeName == pRef.LocalName || strings.HasPrefix(typeName, pRef.LocalName+"_")
 }
 
+// variableDependentBody is used to generate dependent body for variables.
 func variableDependentBody(vars map[string]tfmod.Variable) map[schema.SchemaKey]*schema.BodySchema {
 	depBodies := make(map[schema.SchemaKey]*schema.BodySchema)
 
@@ -290,6 +291,12 @@ func variableDependentBody(vars map[string]tfmod.Variable) map[schema.SchemaKey]
 				{Index: 0, Value: name},
 			},
 		}
+
+		addr := lang.Address{
+			lang.RootStep{Name: "var"},
+			lang.AttrStep{Name: name},
+		}
+
 		depBodies[schema.NewSchemaKey(depKeys)] = &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"default": {
@@ -298,6 +305,7 @@ func variableDependentBody(vars map[string]tfmod.Variable) map[schema.SchemaKey]
 					Description: lang.Markdown("Default value to use when variable is not explicitly set"),
 				},
 			},
+			TargetableAs: targetablesForAddrType(addr, mVar.Type),
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/opentofu/tofu-ls/issues/89

I'm using TargetableAs in order to create the reference between the complex variable attributes and their references in other places.

<img width="587" alt="Screenshot 2025-07-02 at 20 06 46" src="https://github.com/user-attachments/assets/5ad9c7fc-cfaa-43ad-b771-0cf3fca52f4f" />

<img width="1213" alt="Screenshot 2025-07-02 at 20 08 40" src="https://github.com/user-attachments/assets/7eb262f7-8877-4ea9-8c81-d7b364dd0df3" />


