### PR TITLE
fix: test function name

### DIFF
--- a/schema/variable_schema_test.go
+++ b/schema/variable_schema_test.go
@@ -128,7 +128,7 @@ func TestGetTargetablesForAddrType(t *testing.T) {
 		}, []string{"nested_name"}),
 	}, []string{"name", "type"})
 
-	actualTargetables := getTargetablesForAddrType(addr, rootType)
+	actualTargetables := targetablesForAddrType(addr, rootType)
 	expectedTargetables := schema.Targetables{
 		&schema.Targetable{
 			Address: lang.Address{


### PR DESCRIPTION
While merging https://github.com/opentofu/opentofu-schema/pull/38 I've made a small change to function's name, but didn't change on the test, and didn't wait to finish so I merged broken code.
In order to prevent that moving forward, I asked the team to create a few rulesets that will prevent me and others of committing the same mistake.