### PR TITLE
Adds back the support for dynamic blocks in provider

### DIFF
--- a/internal/schema/1.9/root.go
+++ b/internal/schema/1.9/root.go
@@ -20,9 +20,7 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs.Blocks["removed"].Body.Blocks["connection"] = v012_mod.ConnectionBlock(v)
 	bs.Blocks["removed"].Body.Blocks["connection"].DependentBody = v1_3_mod.ConnectionDependentBodies(v)
 
-	bs.Blocks["provider"].Body.Extensions = &schema.BodyExtensions{
-		ForEach: true,
-	}
+	bs.Blocks["provider"].Body.Extensions.ForEach = true
 
 	bs.Blocks["terraform"].Body.Blocks["encryption"] = patchEncryptionBlockSchema(bs.Blocks["terraform"].Body.Blocks["encryption"])
 


### PR DESCRIPTION
We've had oversight in https://github.com/opentofu/opentofu-schema/commit/2d7ce01198d3b4de77dc166782a9c9765c438dc4, and by mistake, we overrode the extensions object instead of extending it.
This caused the `dynamic` block in the `provider` block not to work. Resulting in the issue https://github.com/opentofu/tofu-ls/issues/97
This PR changes object assignment and assigns only the `ForEach` property.