### PR TITLE
Remove `fallback` field from `fallback` block

### DIFF
--- a/internal/schema/1.7/encryption.go
+++ b/internal/schema/1.7/encryption.go
@@ -433,19 +433,7 @@ func stateBlock() *schema.BlockSchema {
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{
-				"fallback": {
-					Description: lang.Markdown("Fallback method for reading existing encrypted data"),
-					Body: &schema.BodySchema{
-						Attributes: map[string]*schema.AttributeSchema{
-							"method": {
-								Constraint:  schema.Reference{OfScopeId: refscope.EncryptionMethodScope},
-								IsRequired:  true,
-								Description: lang.Markdown("Reference to a fallback encryption method"),
-							},
-						},
-					},
-					MaxItems: 1,
-				},
+				"fallback": fallbackSchema(10),
 			},
 		},
 		MaxItems: 1,
@@ -469,15 +457,15 @@ func planBlock() *schema.BlockSchema {
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{
-				"fallback": fallbackSchema(),
+				"fallback": fallbackSchema(10),
 			},
 		},
 		MaxItems: 1,
 	}
 }
 
-func fallbackSchema() *schema.BlockSchema {
-	return &schema.BlockSchema{
+func fallbackSchema(recursiveDepth int) *schema.BlockSchema {
+	block := &schema.BlockSchema{
 		Description: lang.Markdown("Fallback method for reading existing encrypted data"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
@@ -488,15 +476,16 @@ func fallbackSchema() *schema.BlockSchema {
 					IsRequired:  true,
 					Description: lang.Markdown("Reference to a fallback encryption method"),
 				},
-				"fallback": {
-					Constraint:  schema.Reference{OfType: cty.DynamicPseudoType},
-					IsRequired:  true,
-					Description: lang.Markdown("Reference to a fallback encryption method"),
-				},
 			},
 		},
 		MaxItems: 1,
 	}
+	if recursiveDepth == 0 {
+		return block
+	}
+
+	block.Body.Blocks["fallback"] = fallbackSchema(recursiveDepth - 1)
+	return block
 }
 
 func remoteStateDataSourcesBlock() *schema.BlockSchema {
@@ -518,7 +507,7 @@ func remoteStateDataSourcesBlock() *schema.BlockSchema {
 							},
 						},
 						Blocks: map[string]*schema.BlockSchema{
-							"fallback": fallbackSchema(),
+							"fallback": fallbackSchema(10),
 						},
 					},
 					MaxItems: 1,
@@ -542,19 +531,7 @@ func remoteStateDataSourcesBlock() *schema.BlockSchema {
 							},
 						},
 						Blocks: map[string]*schema.BlockSchema{
-							"fallback": {
-								Description: lang.Markdown("Fallback method for reading existing encrypted data"),
-								Body: &schema.BodySchema{
-									Attributes: map[string]*schema.AttributeSchema{
-										"method": {
-											Constraint:  schema.Reference{OfScopeId: refscope.EncryptionMethodScope},
-											IsRequired:  true,
-											Description: lang.Markdown("Reference to a fallback encryption method"),
-										},
-									},
-								},
-								MaxItems: 1,
-							},
+							"fallback": fallbackSchema(10),
 						},
 					},
 				},


### PR DESCRIPTION
While I was working on the key provider for Azure, I noticed there was a required `fallback` field in the `fallback` block of encryption's `plan` block. I've tracked the bug down to here.

Note that both `plan` and `target` are [`EnforceableTargetConfigs`](https://github.com/opentofu/opentofu/blob/main/internal/encryption/config/config.go#L87-L90) and that `fallback` is a `TargetConfig`, which is recursive. This means that `fallback` can also have a fallback. I do not know how to implement that recursive syntax checking yet.

<img width="831" height="117" alt="Screenshot 2025-09-11 at 9 59 53 AM" src="https://github.com/user-attachments/assets/8b2ded89-ed76-4969-a8cf-e044ca415e31" />
