### PR TITLE
checks for resource name while building its link to the docs

### DIFF
--- a/schema/data_resource_schema.go
+++ b/schema/data_resource_schema.go
@@ -75,15 +75,14 @@ func (sm *SchemaMerger) mergeDataSourceSchema(bSchema *schema.BodySchema, dsName
 		namespace = "hashicorp"
 	}
 	if namespace != "" {
-		var registryName string
+		// In OpenTofu's Search Registry, we don't save the data source prefix on the URL, example:
+		// random_uuid becomes uuid on the URL
+		registryDataSourceName := dsName
 		if len(providerAddr.Type)+1 <= len(dsName) {
-			// In OpenTofu's Search Registry, we don't save the data source prefix on the URL, example:
-			// random_uuid becomes uuid on the URL
-			registryName = dsName[len(providerAddr.Type)+1:]
-		} else {
-			registryName = dsName
+			registryDataSourceName = dsName[len(providerAddr.Type)+1:]
 		}
-		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/datasources/%s", namespace, providerAddr.Type, registryName)
+
+		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/datasources/%s", namespace, providerAddr.Type, registryDataSourceName)
 		dsSchema.DocsLink = &schema.DocsLink{
 			URL:     docsUrl,
 			Tooltip: fmt.Sprintf("%s/%s/%s Documentation", namespace, providerAddr.Type, dsName),

--- a/schema/resource_schema.go
+++ b/schema/resource_schema.go
@@ -36,8 +36,11 @@ func (bs *SchemaMerger) mergeResourceSchema(bSchema *schema.BodySchema, rName st
 	if namespace != "" {
 		// In OpenTofu's Search Registry, we don't save the resource prefix on the URL, example:
 		// random_uuid becomes uuid on the URL
-		registryName := rName[len(providerAddr.Type)+1:]
-		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/resources/%s", namespace, providerAddr.Type, registryName)
+		registryResourceName := rName
+		if len(providerAddr.Type)+1 <= len(rName) {
+			registryResourceName = rName[len(providerAddr.Type)+1:]
+		}
+		docsUrl := fmt.Sprintf("https://search.opentofu.org/provider/%s/%s/latest/docs/resources/%s", namespace, providerAddr.Type, registryResourceName)
 		rSchema.DocsLink = &schema.DocsLink{
 			URL:     docsUrl,
 			Tooltip: fmt.Sprintf("%s/%s/%s Documentation", namespace, providerAddr.Type, rName),


### PR DESCRIPTION
Fixes https://github.com/opentofu/tofu-ls/issues/122

- Fix a panic if the resource name isn't in the expected format
- Change the variable name to a clearer intent on what's being used for