### PR TITLE
Added support for the opentofu 1.12 language block

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -71,6 +71,50 @@ terraform {
 			nil,
 		},
 		{
+			"core requirements via language block compatible_with",
+			`
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+  }
+}`,
+			&module.Meta{
+				Path:                 path,
+				CoreRequirements:     version.MustConstraints(version.NewConstraint(">= 1.12")),
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls:          map[string]module.DeclaredModuleCall{},
+			},
+			nil,
+		},
+		{
+			"core requirements from both terraform and language blocks",
+			`
+terraform {
+  required_version = "~> 1.12"
+}
+
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+  }
+}`,
+			&module.Meta{
+				Path:                 path,
+				CoreRequirements:     version.MustConstraints(version.NewConstraint("~> 1.12, >= 1.12")),
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls:          map[string]module.DeclaredModuleCall{},
+			},
+			nil,
+		},
+		{
 			"legacy inferred provider requirements",
 			`
 provider "aws" {

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -68,6 +68,30 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 	for _, block := range content.Blocks {
 		switch block.Type {
 
+		case "language":
+			content, _, contentDiags := block.Body.PartialContent(languageBlockSchema)
+			diags = append(diags, contentDiags...)
+
+			for _, innerBlock := range content.Blocks {
+				if innerBlock.Type != "compatible_with" {
+					continue
+				}
+
+				cwContent, _, cwDiags := innerBlock.Body.PartialContent(languageCompatibleWithSchema)
+				diags = append(diags, cwDiags...)
+
+				// similar logic to the "terraform.required_version" validation below
+				// we want to use the same validation logic for this.
+				if attr, defined := cwContent.Attributes["opentofu"]; defined {
+					var version string
+					valDiags := gohcl.DecodeExpression(attr.Expr, nil, &version)
+					diags = append(diags, valDiags...)
+					if !valDiags.HasErrors() {
+						mod.RequiredCore = append(mod.RequiredCore, version)
+					}
+				}
+			}
+
 		case "terraform":
 			content, _, contentDiags := block.Body.PartialContent(terraformBlockSchema)
 			diags = append(diags, contentDiags...)

--- a/earlydecoder/schema.go
+++ b/earlydecoder/schema.go
@@ -15,6 +15,9 @@ var rootSchema = &hcl.BodySchema{
 			Type: "terraform",
 		},
 		{
+			Type: "language",
+		},
+		{
 			Type:       "provider",
 			LabelNames: []string{"name"},
 		},
@@ -61,6 +64,24 @@ var terraformBlockSchema = &hcl.BodySchema{
 		{
 			Type:       "backend",
 			LabelNames: []string{"type"},
+		},
+	},
+}
+
+// languageBlockSchema describes the `language` block introduced in OpenTofu
+// v1.12.
+var languageBlockSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type: "compatible_with",
+		},
+	},
+}
+
+var languageCompatibleWithSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "opentofu",
 		},
 	},
 }

--- a/internal/schema/1.12/language_block.go
+++ b/internal/schema/1.12/language_block.go
@@ -1,0 +1,64 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2024 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/opentofu/opentofu-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// languageBlockSchema returns the schema for the `language` block introduced
+// in OpenTofu v1.12. It is used to configure language-level behaviors such as
+// the language edition and compatibility constraints.
+//
+// https://opentofu.org/docs/language/settings/
+func languageBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Language},
+		Description: lang.Markdown("`language` block used to configure language-level behaviors of OpenTofu, " +
+			"such as the language edition and compatibility constraints. Accepted only in OpenTofu v1.12 and later."),
+		Body: &schema.BodySchema{
+			DocsLink: &schema.DocsLink{
+				URL: "https://opentofu.org/docs/language/settings/",
+			},
+			Attributes: map[string]*schema.AttributeSchema{
+				"edition": {
+					Constraint: schema.Keyword{
+						Keyword: "tofu2024",
+						Name:    "edition",
+					},
+					IsOptional: true,
+					Description: lang.Markdown("Selects the language edition the module is written for. " +
+						"Modules written for OpenTofu should typically not set this argument at all. " +
+						"The only currently-available edition is `tofu2024`."),
+				},
+				"experiments": {
+					Constraint:  schema.Set{},
+					IsOptional:  true,
+					Description: lang.Markdown("A set of experimental language features to enable. "),
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"compatible_with": {
+					Description: lang.Markdown("Declares the version of OpenTofu this module is compatible with, " +
+						"causing OpenTofu to return an error early if the current version does not match."),
+					Body: &schema.BodySchema{
+						Attributes: map[string]*schema.AttributeSchema{
+							"opentofu": {
+								Constraint: schema.LiteralType{Type: cty.String},
+								IsOptional: true,
+								Description: lang.Markdown("Version constraint specifying which versions of OpenTofu " +
+									"this module is compatible with, e.g. `>= 1.12`"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/1.12/root.go
+++ b/internal/schema/1.12/root.go
@@ -20,6 +20,9 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	// Update the lifecycle block to include the "destroy" attribute for version 1.12 retaining resources on destruction
 	bs.Blocks["resource"].Body.Blocks["lifecycle"] = patchResourceLifecycleBlockWithDestroy(bs.Blocks["resource"].Body.Blocks["lifecycle"])
 
+	// Add the new top-level "language" block introduced in version 1.12
+	bs.Blocks["language"] = languageBlockSchema()
+
 	return bs
 }
 

--- a/internal/schema/tokmod/token_modifier.go
+++ b/internal/schema/tokmod/token_modifier.go
@@ -21,6 +21,7 @@ var (
 	Variable          = lang.SemanticTokenModifier("opentofu-variable")
 	Ephemeral         = lang.SemanticTokenModifier("opentofu-ephemeral")
 	Terraform         = lang.SemanticTokenModifier("opentofu-terraform")
+	Language          = lang.SemanticTokenModifier("opentofu-language")
 	Backend           = lang.SemanticTokenModifier("opentofu-backend")
 	Name              = lang.SemanticTokenModifier("opentofu-name")
 	Type              = lang.SemanticTokenModifier("opentofu-type")
@@ -41,6 +42,7 @@ var SupportedModifiers = []lang.SemanticTokenModifier{
 	RequiredProviders,
 	Resource,
 	Terraform,
+	Language,
 	Type,
 	Variable,
 	Ephemeral,

--- a/schema/core_schema_v1_12_test.go
+++ b/schema/core_schema_v1_12_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2024 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+)
+
+func TestCoreModuleSchemaForVersion_v1_12_language(t *testing.T) {
+	v := version.Must(version.NewVersion("1.12.0"))
+	schemaForVersion, err := CoreModuleSchemaForVersion(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	languageBlock, exists := schemaForVersion.Blocks["language"]
+	if !exists {
+		t.Fatal("expected language block in v1.12 schema")
+	}
+
+	if len(languageBlock.Labels) != 0 {
+		t.Errorf("expected language block to have 0 labels, got %d", len(languageBlock.Labels))
+	}
+
+	if _, exists := languageBlock.Body.Attributes["edition"]; !exists {
+		t.Error("expected language block to have edition attribute")
+	}
+
+	if _, exists := languageBlock.Body.Attributes["experiments"]; !exists {
+		t.Error("expected language block to have experiments attribute")
+	}
+
+	compatibleWith, exists := languageBlock.Body.Blocks["compatible_with"]
+	if !exists {
+		t.Fatal("expected language block to have compatible_with block")
+	}
+
+	if _, exists := compatibleWith.Body.Attributes["opentofu"]; !exists {
+		t.Error("expected compatible_with block to have opentofu attribute")
+	}
+}
+
+func TestCoreModuleSchemaForVersion_v1_11_noLanguage(t *testing.T) {
+	v := version.Must(version.NewVersion("1.11.0"))
+	schemaForVersion, err := CoreModuleSchemaForVersion(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, exists := schemaForVersion.Blocks["language"]; exists {
+		t.Error("did not expect language block in v1.11 schema")
+	}
+}

--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,10 +7,26 @@ import (
 
 var (
 	OldestAvailableVersion                     = version.Must(version.NewVersion("1.6.0"))
-	LatestAvailableVersion                     = version.Must(version.NewVersion("1.11.1"))
-	LatestAvailableVersionIncludingPrereleases = version.Must(version.NewVersion("1.11.1"))
+	LatestAvailableVersion                     = version.Must(version.NewVersion("1.12.3"))
+	LatestAvailableVersionIncludingPrereleases = version.Must(version.NewVersion("1.12.3"))
 
 	tofuVersions = version.Collection{
+		version.Must(version.NewVersion("1.12.3")),
+		version.Must(version.NewVersion("1.12.2")),
+		version.Must(version.NewVersion("1.12.1")),
+		version.Must(version.NewVersion("1.12.0")),
+		version.Must(version.NewVersion("1.12.0-rc1")),
+		version.Must(version.NewVersion("1.12.0-beta1")),
+		version.Must(version.NewVersion("1.11.11")),
+		version.Must(version.NewVersion("1.11.10")),
+		version.Must(version.NewVersion("1.11.9")),
+		version.Must(version.NewVersion("1.11.8")),
+		version.Must(version.NewVersion("1.11.7")),
+		version.Must(version.NewVersion("1.11.6")),
+		version.Must(version.NewVersion("1.11.5")),
+		version.Must(version.NewVersion("1.11.4")),
+		version.Must(version.NewVersion("1.11.3")),
+		version.Must(version.NewVersion("1.11.2")),
 		version.Must(version.NewVersion("1.11.1")),
 		version.Must(version.NewVersion("1.11.0")),
 		version.Must(version.NewVersion("1.11.0-rc4")),
@@ -18,6 +34,8 @@ var (
 		version.Must(version.NewVersion("1.11.0-rc2")),
 		version.Must(version.NewVersion("1.11.0-rc1")),
 		version.Must(version.NewVersion("1.11.0-beta1")),
+		version.Must(version.NewVersion("1.10.10")),
+		version.Must(version.NewVersion("1.10.9")),
 		version.Must(version.NewVersion("1.10.8")),
 		version.Must(version.NewVersion("1.10.7")),
 		version.Must(version.NewVersion("1.10.6")),


### PR DESCRIPTION
OpenTofu 1.12 added support for a new block: https://opentofu.org/docs/language/settings/

It was reported in https://github.com/opentofu/tofu-ls/issues/176 that we have not added support for this in tofu-ls. Once this is approved+merged we can ship a new opentofu-schema version and bump tofu-ls accordingly. 

