### PR TITLE
Added early decoder support for module versions and sources

### DIFF
--- a/earlydecoder/decoder.go
+++ b/earlydecoder/decoder.go
@@ -166,6 +166,10 @@ func LoadModule(path string, files map[string]*hcl.File) (*module.Meta, hcl.Diag
 		outputs[key] = *output
 	}
 
+	// Resolve module calls whose source or version reference variables or
+	// locals that are known
+	resolveStaticModuleCalls(mod)
+
 	modulesCalls := make(map[string]module.DeclaredModuleCall)
 	for key, moduleCall := range mod.ModuleCalls {
 		modulesCalls[key] = *moduleCall

--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1795,3 +1795,137 @@ func runTestCases(testCases []testCase, t *testing.T, path string) {
 func compareVersionConstraint(x, y *version.Constraint) bool {
 	return x.Equals(y)
 }
+
+func TestLoadModule_staticModuleSources(t *testing.T) {
+	path := t.TempDir()
+
+	tests := []struct {
+		name string
+		cfg  string
+
+		expectedSource  string
+		expectedAddr    module.ModuleSourceAddr
+		expectedVersion string
+	}{
+		{
+			name: "source from literal local",
+			cfg: `
+locals {
+  source = "./m"
+}
+module "m" {
+  source = local.source
+}`,
+			expectedSource: "./m",
+			expectedAddr:   module.LocalSourceAddr("./m"),
+		},
+		{
+			name: "source from variable default",
+			cfg: `
+variable "source" {
+  type    = string
+  default = "./m"
+}
+module "m" {
+  source = var.source
+}`,
+			expectedSource: "./m",
+			expectedAddr:   module.LocalSourceAddr("./m"),
+		},
+		{
+			name: "source from chained locals referencing a variable",
+			cfg: `
+variable "base" {
+  default = "./modules"
+}
+locals {
+  dir    = "vpc"
+  source = "${var.base}/${local.dir}"
+}
+module "m" {
+  source = local.source
+}`,
+			expectedSource: "./modules/vpc",
+			expectedAddr:   module.LocalSourceAddr("./modules/vpc"),
+		},
+		{
+			name: "source resolving to a registry address",
+			cfg: `
+locals {
+  source = "terraform-aws-modules/vpc/aws"
+}
+module "m" {
+  source = local.source
+}`,
+			expectedSource: "terraform-aws-modules/vpc/aws",
+			expectedAddr: tfaddr.Module{
+				Package: tfaddr.ModulePackage{
+					Host:         tfaddr.DefaultModuleRegistryHost,
+					Namespace:    "terraform-aws-modules",
+					Name:         "vpc",
+					TargetSystem: "aws",
+				},
+			},
+		},
+		{
+			name: "version from literal local",
+			cfg: `
+locals {
+  version = "1.2.0"
+}
+module "m" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = local.version
+}`,
+			expectedSource:  "terraform-aws-modules/vpc/aws",
+			expectedVersion: "1.2.0",
+		},
+		{
+			name: "unresolvable source left untouched",
+			cfg: `
+variable "source" {
+  type = string
+}
+module "m" {
+  source = var.source
+}`,
+			expectedSource: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+
+			meta, diags := LoadModule(path, map[string]*hcl.File{"test.tf": f})
+			if diags.HasErrors() {
+				t.Fatalf("unexpected diagnostics: %s", diags)
+			}
+
+			mc, ok := meta.ModuleCalls["m"]
+			if !ok {
+				t.Fatalf("module call %q not found", "m")
+			}
+
+			if mc.RawSourceAddr != tc.expectedSource {
+				t.Fatalf("expected source %q, got %q", tc.expectedSource, mc.RawSourceAddr)
+			}
+
+			if tc.expectedAddr != nil {
+				if diff := cmp.Diff(tc.expectedAddr, mc.SourceAddr, customComparer...); diff != "" {
+					t.Fatalf("source address mismatch: %s", diff)
+				}
+			}
+
+			if tc.expectedVersion != "" {
+				expected := version.MustConstraints(version.NewConstraint(tc.expectedVersion))
+				if diff := cmp.Diff(expected, mc.Version, customComparer...); diff != "" {
+					t.Fatalf("version mismatch: %s", diff)
+				}
+			}
+		})
+	}
+}

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -33,6 +33,11 @@ type decodedModule struct {
 	Variables            map[string]*module.Variable
 	Outputs              map[string]*module.Output
 	ModuleCalls          map[string]*module.DeclaredModuleCall
+
+	// Expressions for us to handle and evaluate for module source/version
+	localExprs         map[string]hcl.Expression
+	moduleSourceExprs  map[string]hcl.Expression
+	moduleVersionExprs map[string]hcl.Expression
 }
 
 func newDecodedModule() *decodedModule {
@@ -47,6 +52,10 @@ func newDecodedModule() *decodedModule {
 		Variables:            make(map[string]*module.Variable),
 		Outputs:              make(map[string]*module.Output),
 		ModuleCalls:          make(map[string]*module.DeclaredModuleCall),
+
+		localExprs:         make(map[string]hcl.Expression),
+		moduleSourceExprs:  make(map[string]hcl.Expression),
+		moduleVersionExprs: make(map[string]hcl.Expression),
 	}
 }
 
@@ -361,21 +370,35 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 			}
 			name := block.Labels[0]
 			source := ""
+			var sourceExpr hcl.Expression
 			var versionCons version.Constraints
 
-			var valDiags hcl.Diagnostics
 			if attr, defined := content.Attributes["source"]; defined {
-				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &source)
-				diags = append(diags, valDiags...)
+				// If the source is defined then we should attempt to decode this now, or later
+				// in a second pass
+				var s string
+				sDiags := gohcl.DecodeExpression(attr.Expr, nil, &s)
+				if sDiags.HasErrors() {
+					// The source references variables or locals; keep the
+					// expression so it can be resolved in a second pass and
+					// matched against its dependent schema.
+					sourceExpr = attr.Expr
+					mod.moduleSourceExprs[name] = attr.Expr
+				} else {
+					source = s
+				}
 			}
 			if attr, defined := content.Attributes["version"]; defined {
+				// similar to the source attribute, let's handle the expression later if we need to.
 				var versionStr string
-				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &versionStr)
-				diags = append(diags, valDiags...)
-				if versionStr != "" {
-					vc, err := version.NewConstraint(versionStr)
-					if err == nil {
-						versionCons = vc
+				vDiags := gohcl.DecodeExpression(attr.Expr, nil, &versionStr)
+				if vDiags.HasErrors() {
+					mod.moduleVersionExprs[name] = attr.Expr
+				} else {
+					if versionStr != "" {
+						if vc, err := version.NewConstraint(versionStr); err == nil {
+							versionCons = vc
+						}
 					}
 				}
 			}
@@ -397,12 +420,20 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 			}
 
 			mod.ModuleCalls[name] = &module.DeclaredModuleCall{
-				LocalName:     name,
-				RawSourceAddr: source,
-				SourceAddr:    module.ParseModuleSourceAddr(source),
-				Version:       versionCons,
-				InputNames:    inputNames,
-				RangePtr:      rng,
+				LocalName:      name,
+				RawSourceAddr:  source,
+				SourceAddr:     module.ParseModuleSourceAddr(source),
+				Version:        versionCons,
+				InputNames:     inputNames,
+				RangePtr:       rng,
+				SourceAddrExpr: sourceExpr,
+			}
+
+		case "locals":
+			// We need the local expressions here to evaluate later
+			attrs, _ := block.Body.JustAttributes()
+			for localName, attr := range attrs {
+				mod.localExprs[localName] = attr.Expr
 			}
 		}
 	}

--- a/earlydecoder/schema.go
+++ b/earlydecoder/schema.go
@@ -45,6 +45,9 @@ var rootSchema = &hcl.BodySchema{
 			Type:       "module",
 			LabelNames: []string{"name"},
 		},
+		{
+			Type: "locals",
+		},
 	},
 }
 

--- a/earlydecoder/staticeval.go
+++ b/earlydecoder/staticeval.go
@@ -1,0 +1,123 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2024 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"maps"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu-schema/module"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// resolveStaticModuleCalls evaluates the source and version of module calls
+// that reference variables or locals.
+func resolveStaticModuleCalls(mod *decodedModule) {
+	// If we have none of the stored expressions to evaluate in this "second pass"
+	// then we can just exit early
+	if len(mod.moduleSourceExprs) == 0 && len(mod.moduleVersionExprs) == 0 {
+		return
+	}
+
+	vars := make(map[string]cty.Value, len(mod.Variables))
+	for name, v := range mod.Variables {
+		if v.DefaultValue != cty.NilVal {
+			vars[name] = v.DefaultValue
+		}
+	}
+
+	locals := resolveLocals(mod.localExprs, vars)
+
+	evalCtx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"var":   objectOrEmpty(vars),
+			"local": objectOrEmpty(locals),
+		},
+	}
+
+	for name, expr := range mod.moduleSourceExprs {
+		mc, ok := mod.ModuleCalls[name]
+		if !ok || mc.RawSourceAddr != "" {
+			continue
+		}
+		if source, ok := evalStaticString(expr, evalCtx); ok && source != "" {
+			mc.RawSourceAddr = source
+			mc.SourceAddr = module.ParseModuleSourceAddr(source)
+		}
+	}
+
+	for name, expr := range mod.moduleVersionExprs {
+		mc, ok := mod.ModuleCalls[name]
+		if !ok || len(mc.Version) > 0 {
+			continue
+		}
+		if versionStr, ok := evalStaticString(expr, evalCtx); ok && versionStr != "" {
+			if vc, err := version.NewConstraint(versionStr); err == nil {
+				mc.Version = vc
+			}
+		}
+	}
+}
+
+func resolveLocals(exprs map[string]hcl.Expression, vars map[string]cty.Value) map[string]cty.Value {
+	resolved := make(map[string]cty.Value, len(exprs))
+	if len(exprs) == 0 {
+		return resolved
+	}
+
+	remaining := make(map[string]hcl.Expression, len(exprs))
+	maps.Copy(remaining, exprs)
+
+	for len(remaining) > 0 {
+		ctx := &hcl.EvalContext{
+			Variables: map[string]cty.Value{
+				"var":   objectOrEmpty(vars),
+				"local": objectOrEmpty(resolved),
+			},
+		}
+
+		progressed := false
+		for name, expr := range remaining {
+			val, diags := expr.Value(ctx)
+			if diags.HasErrors() || val.IsNull() || !val.IsWhollyKnown() {
+				continue
+			}
+			resolved[name] = val
+			delete(remaining, name)
+			progressed = true
+		}
+		// Keep going until we cant progress anymore
+		if !progressed {
+			break
+		}
+	}
+
+	return resolved
+}
+
+// evalStaticString evaluates a string, returns false for second return val if it cant resolve
+func evalStaticString(expr hcl.Expression, evalCtx *hcl.EvalContext) (string, bool) {
+	val, diags := expr.Value(evalCtx)
+	if diags.HasErrors() || val.IsNull() || !val.IsWhollyKnown() {
+		return "", false
+	}
+
+	val, err := convert.Convert(val, cty.String)
+	if err != nil {
+		return "", false
+	}
+
+	return val.AsString(), true
+}
+
+func objectOrEmpty(m map[string]cty.Value) cty.Value {
+	if len(m) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(m)
+}

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -40,6 +40,10 @@ type DeclaredModuleCall struct {
 	Version       version.Constraints
 	InputNames    []string
 	RangePtr      *hcl.Range
+
+	// Store the source address so that we can match against it later
+	// it's not always static!
+	SourceAddrExpr hcl.Expression
 }
 
 func (mc DeclaredModuleCall) Copy() DeclaredModuleCall {
@@ -47,11 +51,12 @@ func (mc DeclaredModuleCall) Copy() DeclaredModuleCall {
 	copy(inputNames, mc.InputNames)
 
 	newModuleCall := DeclaredModuleCall{
-		LocalName:     mc.LocalName,
-		RawSourceAddr: mc.RawSourceAddr,
-		SourceAddr:    mc.SourceAddr,
-		Version:       mc.Version,
-		InputNames:    inputNames,
+		LocalName:      mc.LocalName,
+		RawSourceAddr:  mc.RawSourceAddr,
+		SourceAddr:     mc.SourceAddr,
+		Version:        mc.Version,
+		InputNames:     inputNames,
+		SourceAddrExpr: mc.SourceAddrExpr,
 	}
 
 	if mc.RangePtr != nil {

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfmod "github.com/opentofu/opentofu-schema/module"
 	"github.com/opentofu/opentofu-schema/registry"
 	tfaddr "github.com/opentofu/registry-address"
@@ -157,19 +158,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 	}
 
 	for _, module := range declared {
-		depKeys := schema.DependencyKeys{
-			// Fetching based only on the source can cause conflicts for multiple versions of the same module
-			// specially if they have different versions or the source of those modules have been modified
-			// inside the .terraform folder. This is a compromise that we made in this moment since it would impact only auto completion
-			Attributes: []schema.AttributeDependent{
-				{
-					Name: "source",
-					Expr: schema.ExpressionValue{
-						Static: cty.StringVal(module.RawSourceAddr),
-					},
-				},
-			},
-		}
+		depKeys := moduleSourceDependencyKeys(module)
 
 		switch sourceAddr := module.SourceAddr.(type) {
 		case tfaddr.Module:
@@ -230,6 +219,34 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 	}
 
 	return mergedSchema, nil
+}
+
+// moduleSourceDependencyKeys helps build a set of dependency keys for module sources.
+// When the source is static, we match on it's value { "static" : "./value" }.
+// When the source is a reference to a variable or local, then the LS needs to build
+// a depdendency key to allow us to match on the addresses.
+func moduleSourceDependencyKeys(mc tfmod.DeclaredModuleCall) schema.DependencyKeys {
+	if st, ok := mc.SourceAddrExpr.(*hclsyntax.ScopeTraversalExpr); ok {
+		if addr, err := lang.TraversalToAddress(st.AsTraversal()); err == nil {
+			return schema.DependencyKeys{
+				Attributes: []schema.AttributeDependent{
+					{
+						Name: "source",
+						Expr: schema.ExpressionValue{Address: addr},
+					},
+				},
+			}
+		}
+	}
+
+	return schema.DependencyKeys{
+		Attributes: []schema.AttributeDependent{
+			{
+				Name: "source",
+				Expr: schema.ExpressionValue{Static: cty.StringVal(mc.RawSourceAddr)},
+			},
+		},
+	}
 }
 
 // typeBelongsToProvider returns true if the given type


### PR DESCRIPTION
OpenTofu statically evaluates a module's `source` and `version` when they reference variables or locals, so configurations like this are valid:

```hcl
locals {
  source = "./mod"
}

module "m" {
  source = local.source
}
```

https://github.com/opentofu/tofu-ls/issues/175 was raised, and it seems that tofu-ls doesn't handle these "dynamic" sources at all: the referenced module isn't discovered, so there's no completion or validation for its variables. 

This PR attempts to teach the early decoder to resolve the statically-known cases as best as it can.

This does have some limitations for now. Only statically known values are resolved (literal locals, variables, etc) but references that cant be known statically such as a variable with no default, anything using a built-in function or opentofu property (`path.*` etc) are left unresolved without an error. 

Once this has been merged we can ship a new opentofu-schema version and bump tofu-ls accordingly. tofu-ls should have a new change to respect the new `SourceAddrExpr` property too. I will push a PR shortly for this once we've done a release.
